### PR TITLE
Change organization name to Ocean-UHH

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,7 +9,7 @@ Repositories here are developed by current and past group members and collaborat
 
 ---
   
-## 🧰 Repositories on `ifmeo-hamburg`
+## 🧰 Repositories on `ocean-uhh`
 
 - 🚀 [**seagliderOG1**](http://github.com/ocean-uhh/seagliderOG1) - For translating Seaglider basestation files to [OG1 format](https://oceangliderscommunity.github.io/OG-format-user-manual/OG_Format.html)
 - 🌊 [**WBTSdata**](http://github.com/ocean-uhh/WBTSdata) - For loading hydrographic/LADCP data from the Western Boundary Time Series at 26.5°N in the Atlantic

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-# 👋 Welcome to IFMEO-Hamburg!
+# 👋 Welcome to Ocean-UHH!
 
 This is the GitHub organisation for the [Experimental Oceanography](http://eleanorfrajka.com) group at the [University of Hamburg](https://www.ifm.uni-hamburg.de/en.html) 🌊
 
@@ -11,9 +11,9 @@ Repositories here are developed by current and past group members and collaborat
   
 ## 🧰 Repositories on `ifmeo-hamburg`
 
-- 🚀 [**seagliderOG1**](http://github.com/ifmeo-hamburg/seagliderOG1) - For translating Seaglider basestation files to [OG1 format](https://oceangliderscommunity.github.io/OG-format-user-manual/OG_Format.html)
-- 🌊 [**WBTSdata**](http://github.com/ifmeo-hamburg/WBTSdata) - For loading hydrographic/LADCP data from the Western Boundary Time Series at 26.5°N in the Atlantic
-- 🌡️ [**ctd-tools**](http://github.com/ifmeo-hamburg/ctd-tools) - For loading data from oceanographic instruments in various formats
+- 🚀 [**seagliderOG1**](http://github.com/ocean-uhh/seagliderOG1) - For translating Seaglider basestation files to [OG1 format](https://oceangliderscommunity.github.io/OG-format-user-manual/OG_Format.html)
+- 🌊 [**WBTSdata**](http://github.com/ocean-uhh/WBTSdata) - For loading hydrographic/LADCP data from the Western Boundary Time Series at 26.5°N in the Atlantic
+- 🌡️ [**ctd-tools**](http://github.com/ocean-uhh/ctd-tools) - For loading data from oceanographic instruments in various formats
 
 
 
@@ -28,10 +28,10 @@ Repositories here are developed by current and past group members and collaborat
 
 ## 📘 Coursebooks
 
-- 🔄 [**amoc-course**](http://github.com/ifmeo-hamburg/amoc-course) *(registered students only)* - MSc AMOC course, Summer Semester 2025
-- 🌐 [**seaocn**](http://github.com/ifmeo-hamburg/seaocn) - MSc Seagoing Oceanography, Summer Semester 2024
-- 🛰️ [**messfern**](http://github.com/ifmeo-hamburg/messfern) - BSc Messmethoden und Fernerkundung, Winter Semester 2024/25
-- 🗺️ [**regoz**](http://github.com/ifmeo-hamburg/regoz) - BSc Regional Oceanography, Summer Semester 2024
+- 🔄 [**amoc-course**](http://github.com/ocean-uhh/amoc-course) *(registered students only)* - MSc AMOC course, Summer Semester 2025
+- 🌐 [**seaocn**](http://github.com/ocean-uhh/seaocn) - MSc Seagoing Oceanography, Summer Semester 2024
+- 🛰️ [**messfern**](http://github.com/ocean-uhh/messfern) - BSc Messmethoden und Fernerkundung, Winter Semester 2024/25
+- 🗺️ [**regoz**](http://github.com/ocean-uhh/regoz) - BSc Regional Oceanography, Summer Semester 2024
 
 ---
 


### PR DESCRIPTION
Updated organization name and repository links to reflect the new GitHub organization 'Ocean-UHH'.